### PR TITLE
Import design system

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,5 @@
-module.exports = {
-  reactStrictMode: true,
-}
+const withTM = require('next-transpile-modules')(['components']);
+
+module.exports = withTM({
+  reactStrictMode: true
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "next": "11.0.1",
+    "next-transpile-modules": "^8.0.0",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   },
@@ -18,5 +19,9 @@
     "eslint": "7.29.0",
     "eslint-config-next": "11.0.1",
     "relative-deps": "^1.0.7"
+  },
+  "relativeDependencies": {
+    "theme": "./../css-modules-playground/packages/theme",
+    "components": "./../css-modules-playground/packages/components"
   }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,5 @@
 import '../styles/globals.css'
+import 'theme';
 
 function MyApp({ Component, pageProps }) {
   return <Component {...pageProps} />

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -3,6 +3,8 @@ import styles from "../styles/Home.module.css";
 import Head from "next/head";
 import Image from "next/image";
 
+import {Button, Input} from 'components';
+
 const Contact = () => (
     <div className={styles.container}>
         <Head>
@@ -25,8 +27,8 @@ const Contact = () => (
                     event.preventDefault();
                     console.log('message sent to moose')
                 }}>
-                    <input placeholder={"woof@dogs.com"} />
-                    <button type="submit">{'Subscribe'}</button>
+                    <Input id="email" placeholder="woof@dogs.com" />
+                    <Button type="submit">{'Subscribe'}</Button>
                 </form>
             </main>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1122,6 +1122,14 @@ encoding@0.1.13:
   dependencies:
     iconv-lite "^0.6.2"
 
+enhanced-resolve@^5.7.0:
+  version "5.8.2"
+  resolved "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz#15ddc779345cbb73e97c611cd00c01c1e7bf4d8b"
+  integrity sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
 enquirer@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -1710,7 +1718,7 @@ globby@^9.2.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
-graceful-fs@^4.1.2:
+graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
@@ -2496,6 +2504,14 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+next-transpile-modules@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.npmjs.org/next-transpile-modules/-/next-transpile-modules-8.0.0.tgz#56375cdc25ae5d23a834195f277fc2737b26cb97"
+  integrity sha512-Q2f2yB0zMJ8KJbIYAeZoIxG6cSfVk813zr6B5HzsLMBVcJ3FaF8lKr7WG66n0KlHCwjLSmf/6EkgI6QQVWHrDw==
+  dependencies:
+    enhanced-resolve "^5.7.0"
+    escalade "^3.1.1"
 
 next@11.0.1:
   version "11.0.1"
@@ -3728,6 +3744,11 @@ table@^6.0.9:
     slice-ansi "^4.0.0"
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
+
+tapable@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
+  integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
 
 tar@^6.0.5:
   version "6.1.0"


### PR DESCRIPTION
Imports [design system](https://github.hy-vee.cloud/MMoran/css-modules-playground) using `relative-deps`. 

Noteworthy: 
1. Next does not support css modules using `:root` syntax. See `https://github.com/vercel/next.js/discussions/17089`
2. Needed to add `next-transpile-modules` to transpile the CSS modules from the npm packages. See `https://github.com/vercel/next.js/issues/13282`